### PR TITLE
infering router outputs

### DIFF
--- a/src/app/_components/TodoList.tsx
+++ b/src/app/_components/TodoList.tsx
@@ -2,12 +2,12 @@
 import { useState } from "react";
 
 import { trpc } from "../_trpc/client";
-import { serverClient } from "../_trpc/serverClient";
+import { RouterOutputs } from "@/server";
 
 export default function TodoList({
   initialTodos,
 }: {
-  initialTodos: Awaited<ReturnType<(typeof serverClient)["getTodos"]>>;
+  initialTodos: RouterOutputs["getTodos"];
 }) {
   const getTodos = trpc.getTodos.useQuery(undefined, {
     initialData: initialTodos,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { publicProcedure, router } from "./trpc";
 
 import { todos } from "@/db/schema";
+import { inferRouterOutputs } from "@trpc/server";
 
 const sqlite = new Database("sqlite.db");
 const db = drizzle(sqlite);
@@ -39,3 +40,4 @@ export const appRouter = router({
 });
 
 export type AppRouter = typeof appRouter;
+export type RouterOutputs = inferRouterOutputs<AppRouter>;


### PR DESCRIPTION
There is an easier way to access router output types.

Based on [trpc docs](https://trpc.io/docs/client/vanilla/infer-types#inferring-input--output-types)